### PR TITLE
Improves VerticalDividerItemDecoration when used in a GridLayout

### DIFF
--- a/library/src/main/java/com/yqritc/recyclerviewflexibledivider/FlexibleDividerDecoration.java
+++ b/library/src/main/java/com/yqritc/recyclerviewflexibledivider/FlexibleDividerDecoration.java
@@ -83,8 +83,6 @@ public abstract class FlexibleDividerDecoration extends RecyclerView.ItemDecorat
 
     @Override
     public void onDraw(Canvas c, RecyclerView parent, RecyclerView.State state) {
-        int itemCount = parent.getAdapter().getItemCount();
-        int lastDividerOffset = getLastDividerOffset(parent);
         int validChildCount = parent.getChildCount();
         int lastChildPosition = -1;
         for (int i = 0; i < validChildCount; i++) {
@@ -97,7 +95,7 @@ public abstract class FlexibleDividerDecoration extends RecyclerView.ItemDecorat
             }
             lastChildPosition = childPosition;
 
-            if (!mShowLastDivider && childPosition >= itemCount - lastDividerOffset) {
+            if (!mShowLastDivider && isLastItem(childPosition, parent)) {
                 // Don't draw divider for last line if mShowLastDivider = false
                 continue;
             }
@@ -174,6 +172,20 @@ public abstract class FlexibleDividerDecoration extends RecyclerView.ItemDecorat
     }
 
     /**
+     * In the case mShowLastDivider = false,
+     * Determine whether this child position is the last position (or in the last row), so that
+     * a divider won't be drawn.
+     *
+     * @param parent RecyclerView
+     * @return whether this position is the last position in the recyclerview
+     */
+    protected boolean isLastItem(int childPosition, RecyclerView parent){
+        int itemCount = parent.getAdapter().getItemCount();
+        int lastDividerOffset = getLastDividerOffset(parent);
+        return childPosition >= itemCount - lastDividerOffset;
+    }
+
+    /**
      * Determines whether divider was already drawn for the row the item is in,
      * effectively only makes sense for a grid
      *
@@ -181,16 +193,8 @@ public abstract class FlexibleDividerDecoration extends RecyclerView.ItemDecorat
      * @param parent   RecyclerView
      * @return true if the divider can be skipped as it is in the same row as the previous one.
      */
-    private boolean wasDividerAlreadyDrawn(int position, RecyclerView parent) {
-        if (parent.getLayoutManager() instanceof GridLayoutManager) {
-            GridLayoutManager layoutManager = (GridLayoutManager) parent.getLayoutManager();
-            GridLayoutManager.SpanSizeLookup spanSizeLookup = layoutManager.getSpanSizeLookup();
-            int spanCount = layoutManager.getSpanCount();
-            return spanSizeLookup.getSpanIndex(position, spanCount) > 0;
-        }
+    protected abstract boolean wasDividerAlreadyDrawn(int position, RecyclerView parent);
 
-        return false;
-    }
 
     /**
      * Returns a group index for GridLayoutManager.

--- a/library/src/main/java/com/yqritc/recyclerviewflexibledivider/HorizontalDividerItemDecoration.java
+++ b/library/src/main/java/com/yqritc/recyclerviewflexibledivider/HorizontalDividerItemDecoration.java
@@ -5,6 +5,7 @@ import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.DimenRes;
 import android.support.v4.view.ViewCompat;
+import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
 
@@ -58,6 +59,18 @@ public class HorizontalDividerItemDecoration extends FlexibleDividerDecoration {
             return drawable.getIntrinsicHeight();
         }
         throw new RuntimeException("failed to get size");
+    }
+
+    @Override
+    protected boolean wasDividerAlreadyDrawn(int position, RecyclerView parent) {
+        if (parent.getLayoutManager() instanceof GridLayoutManager) {
+            GridLayoutManager layoutManager = (GridLayoutManager) parent.getLayoutManager();
+            GridLayoutManager.SpanSizeLookup spanSizeLookup = layoutManager.getSpanSizeLookup();
+            int spanCount = layoutManager.getSpanCount();
+            return spanSizeLookup.getSpanIndex(position, spanCount) > 0;
+        }
+
+        return false;
     }
 
     /**

--- a/library/src/main/java/com/yqritc/recyclerviewflexibledivider/VerticalDividerItemDecoration.java
+++ b/library/src/main/java/com/yqritc/recyclerviewflexibledivider/VerticalDividerItemDecoration.java
@@ -5,6 +5,7 @@ import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.DimenRes;
 import android.support.v4.view.ViewCompat;
+import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
 
@@ -23,24 +24,40 @@ public class VerticalDividerItemDecoration extends FlexibleDividerDecoration {
     @Override
     protected Rect getDividerBound(int position, RecyclerView parent, View child) {
         Rect bounds = new Rect(0, 0, 0, 0);
-        int transitionX = (int) ViewCompat.getTranslationX(child);
-        int transitionY = (int) ViewCompat.getTranslationY(child);
+        int viewY = (int) ViewCompat.getY(child);
+
         RecyclerView.LayoutParams params = (RecyclerView.LayoutParams) child.getLayoutParams();
         bounds.top = parent.getPaddingTop() +
-                mMarginProvider.dividerTopMargin(position, parent) + transitionY;
-        bounds.bottom = parent.getHeight() - parent.getPaddingBottom() -
-                mMarginProvider.dividerBottomMargin(position, parent) + transitionY;
+                mMarginProvider.dividerTopMargin(position, parent) + viewY;
+        bounds.bottom = viewY + child.getMeasuredHeight()
+                - mMarginProvider.dividerBottomMargin(position,parent);
 
         int dividerSize = getDividerSize(position, parent);
         if (mDividerType == DividerType.DRAWABLE) {
-            bounds.left = child.getRight() + params.leftMargin + transitionX;
+            bounds.left = child.getRight() + params.leftMargin;
             bounds.right = bounds.left + dividerSize;
         } else {
-            bounds.left = child.getRight() + params.leftMargin + dividerSize / 2 + transitionX;
+            bounds.left = child.getRight() + params.leftMargin + dividerSize / 2;
             bounds.right = bounds.left;
         }
 
         return bounds;
+    }
+
+    @Override
+    protected boolean wasDividerAlreadyDrawn(int position, RecyclerView parent) {
+        return false;
+    }
+
+    protected boolean isLastItem(int childPosition, RecyclerView parent){
+        if (parent.getLayoutManager() instanceof GridLayoutManager) {
+            GridLayoutManager layoutManager = (GridLayoutManager) parent.getLayoutManager();
+            GridLayoutManager.SpanSizeLookup spanSizeLookup = layoutManager.getSpanSizeLookup();
+            int spanCount = layoutManager.getSpanCount();
+            return spanSizeLookup.getSpanIndex(childPosition, spanCount) == spanCount - 1;
+        }
+
+        return super.isLastItem(childPosition, parent);
     }
 
     @Override

--- a/sample/src/main/java/com/yqritc/recyclerviewflexibledivider/sample/SimpleGridActivity.java
+++ b/sample/src/main/java/com/yqritc/recyclerviewflexibledivider/sample/SimpleGridActivity.java
@@ -1,7 +1,5 @@
 package com.yqritc.recyclerviewflexibledivider.sample;
 
-import com.yqritc.recyclerviewflexibledivider.HorizontalDividerItemDecoration;
-
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
@@ -11,6 +9,9 @@ import android.support.v7.widget.OrientationHelper;
 import android.support.v7.widget.RecyclerView;
 import android.view.Menu;
 import android.view.MenuItem;
+
+import com.yqritc.recyclerviewflexibledivider.HorizontalDividerItemDecoration;
+import com.yqritc.recyclerviewflexibledivider.VerticalDividerItemDecoration;
 
 
 public class SimpleGridActivity extends AppCompatActivity {
@@ -27,12 +28,13 @@ public class SimpleGridActivity extends AppCompatActivity {
         setContentView(R.layout.activity_sample);
 
         SimpleAdapter adapter = new SimpleAdapter(this);
-        GridLayoutManager manager = new GridLayoutManager(this, 3);
+        final GridLayoutManager manager = new GridLayoutManager(this, 3);
         manager.setOrientation(OrientationHelper.VERTICAL);
         RecyclerView recyclerView = (RecyclerView) findViewById(R.id.main_recyclerview);
         recyclerView.setLayoutManager(manager);
         recyclerView.setAdapter(adapter);
         recyclerView.addItemDecoration(new HorizontalDividerItemDecoration.Builder(this).build());
+        recyclerView.addItemDecoration(new VerticalDividerItemDecoration.Builder(this).build());
     }
 
 


### PR DESCRIPTION
The VerticalDividerItemDecoration was being drawn over the entire recyclerview, rather than just the cell bounds for each position.

This meant that shouldHideDivider() had no effect.

The bounds calcutation for the VerticalDividerItemDecoration is now correct.

ShowLastDivider behaviour is also now supported for VerticalDividerItemDecoration in a GridLayout
