### PR TITLE
Add support for AboutLibraries

### DIFF
--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="define_recyclerview_flexibledivider" />
+    <string name="library_recyclerview_flexibledivider_author">Yoshihito Ikeda</string>
+    <string name="library_recyclerview_flexibledivider_authorWebsite">https://github.com/yqritc</string>
+    <string name="library_recyclerview_flexibledivider_libraryName">RecyclerView-FlexibleDivider</string>
+    <string name="library_recyclerview_flexibledivider_libraryDescription">Android library providing a simple way to control divider items (ItemDecoration) of RecyclerViews</string>
+    <string name="library_recyclerview_flexibledivider_libraryWebsite">https://github.com/yqritc/RecyclerView-FlexibleDivider</string>
+    <string name="library_recyclerview_flexibledivider_libraryVersion">1.4.0</string>
+    <string name="library_recyclerview_flexibledivider_isOpenSource">true</string>
+    <string name="library_recyclerview_flexibledivider_repositoryLink">https://github.com/yqritc/RecyclerView-FlexibleDivider</string>
+    <string name="library_recyclerview_flexibledivider_classPath">com.yqritc.recyclerviewflexibledivider</string>
+    <string name="library_recyclerview_flexibledivider_licenseId">apache_2_0</string>
+</resources>


### PR DESCRIPTION
This PR adds support for [AboutLibraries](https://github.com/mikepenz/AboutLibraries). By adding these additions in `strings.xml`, AboutLibraries automatically recognizes this library and shows the correct license and author information.

This definition is built using the [definition generator](http://def-builder.mikepenz.com/) on the AboutLibraries website.

I would like to merge these changes as I'm using the FlexibleDivider library and I would like to use AboutLibraries with an appropriate attribution :-)
