### PR TITLE
Add support annotations for pixel dimension and color int

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.2.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.0'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,10 @@ buildscript {
     }
 }
 
+ext {
+    supportLibVersion = '24.2.1'
+}
+
 allprojects {
     repositories {
         jcenter()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jun 23 11:31:54 JST 2016
+#Tue Sep 27 16:13:47 CEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -13,8 +13,8 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:23.4.0'
-    compile 'com.android.support:recyclerview-v7:23.4.0'
+    compile "com.android.support:appcompat-v7:$supportLibVersion"
+    compile "com.android.support:recyclerview-v7:$supportLibVersion"
 }
 
 android.libraryVariants.all { variant ->

--- a/library/src/main/java/com/yqritc/recyclerviewflexibledivider/FlexibleDividerDecoration.java
+++ b/library/src/main/java/com/yqritc/recyclerviewflexibledivider/FlexibleDividerDecoration.java
@@ -7,9 +7,11 @@ import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
+import android.support.annotation.ColorInt;
 import android.support.annotation.ColorRes;
 import android.support.annotation.DimenRes;
 import android.support.annotation.DrawableRes;
+import android.support.annotation.Px;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.LinearLayoutManager;
@@ -354,7 +356,7 @@ public abstract class FlexibleDividerDecoration extends RecyclerView.ItemDecorat
             return (T) this;
         }
 
-        public T color(final int color) {
+        public T color(@ColorInt final int color) {
             return colorProvider(new ColorProvider() {
                 @Override
                 public int dividerColor(int position, RecyclerView parent) {
@@ -390,7 +392,7 @@ public abstract class FlexibleDividerDecoration extends RecyclerView.ItemDecorat
             return (T) this;
         }
 
-        public T size(final int size) {
+        public T size(@Px final int size) {
             return sizeProvider(new SizeProvider() {
                 @Override
                 public int dividerSize(int position, RecyclerView parent) {

--- a/library/src/main/java/com/yqritc/recyclerviewflexibledivider/HorizontalDividerItemDecoration.java
+++ b/library/src/main/java/com/yqritc/recyclerviewflexibledivider/HorizontalDividerItemDecoration.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.DimenRes;
+import android.support.annotation.Px;
 import android.support.v4.view.ViewCompat;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
@@ -104,6 +105,7 @@ public class HorizontalDividerItemDecoration extends FlexibleDividerDecoration {
          * @param parent   RecyclerView
          * @return left margin
          */
+        @Px
         int dividerLeftMargin(int position, RecyclerView parent);
 
         /**
@@ -113,6 +115,7 @@ public class HorizontalDividerItemDecoration extends FlexibleDividerDecoration {
          * @param parent   RecyclerView
          * @return right margin
          */
+        @Px
         int dividerRightMargin(int position, RecyclerView parent);
     }
 
@@ -134,7 +137,7 @@ public class HorizontalDividerItemDecoration extends FlexibleDividerDecoration {
             super(context);
         }
 
-        public Builder margin(final int leftMargin, final int rightMargin) {
+        public Builder margin(@Px final int leftMargin, @Px final int rightMargin) {
             return marginProvider(new MarginProvider() {
                 @Override
                 public int dividerLeftMargin(int position, RecyclerView parent) {
@@ -148,7 +151,7 @@ public class HorizontalDividerItemDecoration extends FlexibleDividerDecoration {
             });
         }
 
-        public Builder margin(int horizontalMargin) {
+        public Builder margin(@Px int horizontalMargin) {
             return margin(horizontalMargin, horizontalMargin);
         }
 

--- a/library/src/main/java/com/yqritc/recyclerviewflexibledivider/VerticalDividerItemDecoration.java
+++ b/library/src/main/java/com/yqritc/recyclerviewflexibledivider/VerticalDividerItemDecoration.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.DimenRes;
+import android.support.annotation.Px;
 import android.support.v4.view.ViewCompat;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
@@ -104,6 +105,7 @@ public class VerticalDividerItemDecoration extends FlexibleDividerDecoration {
          * @param parent   RecyclerView
          * @return top margin
          */
+        @Px
         int dividerTopMargin(int position, RecyclerView parent);
 
         /**
@@ -113,6 +115,7 @@ public class VerticalDividerItemDecoration extends FlexibleDividerDecoration {
          * @param parent   RecyclerView
          * @return bottom margin
          */
+        @Px
         int dividerBottomMargin(int position, RecyclerView parent);
     }
 
@@ -134,7 +137,7 @@ public class VerticalDividerItemDecoration extends FlexibleDividerDecoration {
             super(context);
         }
 
-        public Builder margin(final int topMargin, final int bottomMargin) {
+        public Builder margin(@Px final int topMargin, @Px final int bottomMargin) {
             return marginProvider(new MarginProvider() {
                 @Override
                 public int dividerTopMargin(int position, RecyclerView parent) {
@@ -148,7 +151,7 @@ public class VerticalDividerItemDecoration extends FlexibleDividerDecoration {
             });
         }
 
-        public Builder margin(int verticalMargin) {
+        public Builder margin(@Px int verticalMargin) {
             return margin(verticalMargin, verticalMargin);
         }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -22,6 +22,6 @@ android {
 dependencies {
     compile project(':library')
 //    compile 'com.yqritc:recyclerview-flexibledivider:1.4.0'
-    compile 'com.android.support:appcompat-v7:23.4.0'
-    compile 'com.android.support:recyclerview-v7:23.4.0'
+    compile "com.android.support:appcompat-v7:$supportLibVersion"
+    compile "com.android.support:recyclerview-v7:$supportLibVersion"
 }


### PR DESCRIPTION
Today I spent half an hour debugging why nothing shows in my recycler.
I called `size(R.dimen.home_item_spacing)` instead of `sizeResId(R.dimen.home_item_spacing)` which resulted in a huge divider spacing.

These changes will make lint warn about that problem and some related problems (margins an color ints).
